### PR TITLE
feat: add initial project structure with headless core and framework bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+*.tsbuildinfo
+
+# Bun
+bun.lock
+
+# IDE
+.idea/
+*.swp
+*.swo
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Test coverage
+coverage/
+
+# Temporary files
+*.tmp
+*.temp
+.cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Seiji Kohara
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+# Teppan
+
+A headless code editor library with framework-agnostic core and official bindings for major UI frameworks.
+
+## Overview
+
+Teppan provides a modular architecture that separates editor logic from rendering. The core package handles state management, text manipulation, and event handling, while framework-specific packages provide components and hooks for integration.
+
+The headless design allows the core functionality to be used with any UI framework or without a framework at all.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `@teppan/core` | Framework-agnostic headless core. Provides editor state management, text manipulation, and event handling. |
+| `@teppan/react` | React bindings. Provides React components and hooks for integration. |
+| `@teppan/vue` | Vue 3 bindings. Provides Vue components and composables for integration. |
+| `@teppan/svelte` | Svelte 5 bindings. Provides Svelte components with runes support. |
+
+## Requirements
+
+- [Bun](https://bun.sh/) >= 1.1.0
+- Node.js >= 20.0.0
+
+## Installation
+
+```bash
+# Install all dependencies
+bun install
+
+# Build all packages
+bun run build
+```
+
+## Development
+
+```bash
+# Watch mode for all packages
+bun run dev
+
+# Type checking
+bun run typecheck
+
+# Linting
+bun run lint
+
+# Build specific package
+bun run --filter @teppan/core build
+```
+
+## Usage
+
+### React
+
+```tsx
+import { CodeEditor, useEditor } from '@teppan/react';
+
+function App() {
+  return (
+    <CodeEditor
+      initialContent="console.log('Hello');"
+      language="javascript"
+      onChange={(content) => console.log(content)}
+    />
+  );
+}
+```
+
+### Vue 3
+
+```vue
+<script setup>
+import { CodeEditor } from '@teppan/vue';
+import { ref } from 'vue';
+
+const code = ref('console.log("Hello");');
+</script>
+
+<template>
+  <CodeEditor v-model="code" language="javascript" />
+</template>
+```
+
+### Svelte 5
+
+```svelte
+<script>
+  import { CodeEditor } from '@teppan/svelte';
+
+  let code = $state('console.log("Hello");');
+</script>
+
+<CodeEditor bind:value={code} language="javascript" />
+```
+
+### Headless Core
+
+```typescript
+import { Editor } from '@teppan/core';
+
+const editor = new Editor(
+  { initialContent: 'Hello', language: 'plaintext' },
+  { onChange: (content) => console.log(content) }
+);
+
+editor.insertText(' World');
+console.log(editor.getContent()); // "Hello World"
+```
+
+## Architecture
+
+```
+teppan/
+├── packages/
+│   ├── core/           # Headless core
+│   │   └── src/
+│   │       ├── editor.ts
+│   │       ├── types.ts
+│   │       └── index.ts
+│   ├── react/          # React bindings
+│   │   └── src/
+│   │       ├── CodeEditor.tsx
+│   │       ├── useEditor.ts
+│   │       └── index.ts
+│   ├── vue/            # Vue 3 bindings
+│   │   └── src/
+│   │       ├── CodeEditor.vue
+│   │       ├── useEditor.ts
+│   │       └── index.ts
+│   └── svelte/         # Svelte 5 bindings
+│       └── src/
+│           ├── CodeEditor.svelte
+│           ├── createEditor.svelte.ts
+│           └── index.ts
+├── package.json
+├── tsconfig.json
+└── biome.json
+```
+
+## License
+
+MIT

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  },
+  "files": {
+    "ignore": [
+      "node_modules",
+      "dist",
+      "*.svelte",
+      "*.vue"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "teppan",
+  "version": "0.0.1",
+  "description": "A headless code editor library with framework-agnostic core and official bindings for major UI frameworks.",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/teppan.git"
+  },
+  "keywords": [
+    "code-editor",
+    "editor",
+    "headless",
+    "typescript"
+  ],
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "bun run --filter '*' build",
+    "dev": "bun run --filter '*' dev",
+    "test": "bun run --filter '*' test",
+    "lint": "bun run --filter '*' lint",
+    "typecheck": "bun run --filter '*' typecheck",
+    "clean": "bun run --filter '*' clean"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "packageManager": "bun@1.1.38"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@teppan/core",
+  "version": "0.0.1",
+  "description": "Framework-agnostic headless core for the Teppan code editor. Provides editor state management, text manipulation, and event handling.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/teppan.git",
+    "directory": "packages/core"
+  },
+  "keywords": [
+    "teppan",
+    "code-editor",
+    "editor",
+    "headless",
+    "typescript"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -1,0 +1,229 @@
+import type {
+  EditorOptions,
+  EditorState,
+  EditorEvents,
+  Position,
+  Selection,
+} from "./types";
+
+const DEFAULT_OPTIONS: Required<EditorOptions> = {
+  initialContent: "",
+  language: "plaintext",
+  readOnly: false,
+  tabSize: 2,
+  lineNumbers: true,
+  wordWrap: false,
+};
+
+/**
+ * Headless code editor core
+ *
+ * This class provides the core logic for a code editor without any
+ * framework-specific rendering. It manages state and emits events
+ * that can be consumed by framework-specific wrappers.
+ */
+export class Editor {
+  private options: Required<EditorOptions>;
+  private events: EditorEvents;
+  private state: EditorState;
+
+  constructor(options: EditorOptions = {}, events: EditorEvents = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+    this.events = events;
+    this.state = {
+      content: this.options.initialContent,
+      cursor: { line: 0, column: 0 },
+      selection: null,
+      isDirty: false,
+      language: this.options.language,
+    };
+  }
+
+  /**
+   * Get the current editor state
+   */
+  getState(): Readonly<EditorState> {
+    return { ...this.state };
+  }
+
+  /**
+   * Get the current content
+   */
+  getContent(): string {
+    return this.state.content;
+  }
+
+  /**
+   * Set the content of the editor
+   */
+  setContent(content: string): void {
+    if (this.options.readOnly) return;
+
+    this.state.content = content;
+    this.state.isDirty = true;
+    this.events.onChange?.(content);
+  }
+
+  /**
+   * Insert text at the current cursor position
+   */
+  insertText(text: string): void {
+    if (this.options.readOnly) return;
+
+    const lines = this.state.content.split("\n");
+    const { line, column } = this.state.cursor;
+
+    if (lines[line] !== undefined) {
+      const currentLine = lines[line];
+      lines[line] =
+        currentLine.slice(0, column) + text + currentLine.slice(column);
+    }
+
+    this.state.content = lines.join("\n");
+    this.state.cursor.column += text.length;
+    this.state.isDirty = true;
+
+    this.events.onChange?.(this.state.content);
+    this.events.onCursorChange?.(this.state.cursor);
+  }
+
+  /**
+   * Delete text at the current cursor position
+   */
+  deleteText(count: number = 1): void {
+    if (this.options.readOnly) return;
+
+    const lines = this.state.content.split("\n");
+    const { line, column } = this.state.cursor;
+
+    if (lines[line] !== undefined) {
+      const currentLine = lines[line];
+      lines[line] =
+        currentLine.slice(0, Math.max(0, column - count)) +
+        currentLine.slice(column);
+      this.state.cursor.column = Math.max(0, column - count);
+    }
+
+    this.state.content = lines.join("\n");
+    this.state.isDirty = true;
+
+    this.events.onChange?.(this.state.content);
+    this.events.onCursorChange?.(this.state.cursor);
+  }
+
+  /**
+   * Set the cursor position
+   */
+  setCursor(position: Position): void {
+    const lines = this.state.content.split("\n");
+    const maxLine = Math.max(0, lines.length - 1);
+    const line = Math.max(0, Math.min(position.line, maxLine));
+    const maxColumn = lines[line]?.length ?? 0;
+    const column = Math.max(0, Math.min(position.column, maxColumn));
+
+    this.state.cursor = { line, column };
+    this.events.onCursorChange?.(this.state.cursor);
+  }
+
+  /**
+   * Set the selection range
+   */
+  setSelection(selection: Selection | null): void {
+    this.state.selection = selection;
+    this.events.onSelectionChange?.(selection);
+  }
+
+  /**
+   * Get the selected text
+   */
+  getSelectedText(): string {
+    if (!this.state.selection) return "";
+
+    const { start, end } = this.state.selection;
+    const lines = this.state.content.split("\n");
+
+    if (start.line === end.line) {
+      return lines[start.line]?.slice(start.column, end.column) ?? "";
+    }
+
+    const selectedLines: string[] = [];
+    for (let i = start.line; i <= end.line; i++) {
+      const line = lines[i];
+      if (line === undefined) continue;
+
+      if (i === start.line) {
+        selectedLines.push(line.slice(start.column));
+      } else if (i === end.line) {
+        selectedLines.push(line.slice(0, end.column));
+      } else {
+        selectedLines.push(line);
+      }
+    }
+
+    return selectedLines.join("\n");
+  }
+
+  /**
+   * Set the language mode
+   */
+  setLanguage(language: string): void {
+    this.state.language = language;
+  }
+
+  /**
+   * Get the current options
+   */
+  getOptions(): Readonly<Required<EditorOptions>> {
+    return { ...this.options };
+  }
+
+  /**
+   * Update options
+   */
+  updateOptions(options: Partial<EditorOptions>): void {
+    this.options = { ...this.options, ...options };
+  }
+
+  /**
+   * Mark the content as saved (not dirty)
+   */
+  markSaved(): void {
+    this.state.isDirty = false;
+  }
+
+  /**
+   * Get the number of lines
+   */
+  getLineCount(): number {
+    return this.state.content.split("\n").length;
+  }
+
+  /**
+   * Get a specific line's content
+   */
+  getLine(lineNumber: number): string | undefined {
+    const lines = this.state.content.split("\n");
+    return lines[lineNumber];
+  }
+
+  /**
+   * Handle focus event
+   */
+  focus(): void {
+    this.events.onFocus?.();
+  }
+
+  /**
+   * Handle blur event
+   */
+  blur(): void {
+    this.events.onBlur?.();
+  }
+
+  /**
+   * Destroy the editor and clean up
+   */
+  destroy(): void {
+    this.events = {};
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+export { Editor } from "./editor";
+export type { EditorOptions, EditorState, EditorEvents } from "./types";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Editor configuration options
+ */
+export interface EditorOptions {
+  /** Initial content of the editor */
+  initialContent?: string;
+  /** Language mode for syntax highlighting */
+  language?: string;
+  /** Enable read-only mode */
+  readOnly?: boolean;
+  /** Tab size in spaces */
+  tabSize?: number;
+  /** Enable line numbers */
+  lineNumbers?: boolean;
+  /** Enable word wrap */
+  wordWrap?: boolean;
+}
+
+/**
+ * Represents a position in the editor
+ */
+export interface Position {
+  /** Line number (0-indexed) */
+  line: number;
+  /** Column number (0-indexed) */
+  column: number;
+}
+
+/**
+ * Represents a selection range in the editor
+ */
+export interface Selection {
+  /** Start position of the selection */
+  start: Position;
+  /** End position of the selection */
+  end: Position;
+}
+
+/**
+ * Current state of the editor
+ */
+export interface EditorState {
+  /** Current content of the editor */
+  content: string;
+  /** Current cursor position */
+  cursor: Position;
+  /** Current selection (null if no selection) */
+  selection: Selection | null;
+  /** Whether the content has been modified */
+  isDirty: boolean;
+  /** Current language mode */
+  language: string;
+}
+
+/**
+ * Editor event handlers
+ */
+export interface EditorEvents {
+  /** Called when content changes */
+  onChange?: (content: string) => void;
+  /** Called when cursor position changes */
+  onCursorChange?: (position: Position) => void;
+  /** Called when selection changes */
+  onSelectionChange?: (selection: Selection | null) => void;
+  /** Called when the editor gains focus */
+  onFocus?: () => void;
+  /** Called when the editor loses focus */
+  onBlur?: () => void;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@teppan/react",
+  "version": "0.0.1",
+  "description": "React bindings for the Teppan code editor. Provides React components and hooks for integrating the editor into React applications.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/teppan.git",
+    "directory": "packages/react"
+  },
+  "keywords": [
+    "teppan",
+    "code-editor",
+    "editor",
+    "react",
+    "typescript"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "dependencies": {
+    "@teppan/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
+    "@vitejs/plugin-react": "^4.3.4",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5",
+    "vite-plugin-dts": "^4.3.0"
+  }
+}

--- a/packages/react/src/CodeEditor.tsx
+++ b/packages/react/src/CodeEditor.tsx
@@ -1,0 +1,99 @@
+import {
+  useRef,
+  useEffect,
+  useCallback,
+  type KeyboardEvent,
+  type ChangeEvent,
+} from "react";
+import { useEditor, type UseEditorOptions } from "./useEditor";
+
+export interface CodeEditorProps extends UseEditorOptions {
+  /** CSS class name for the container */
+  className?: string;
+  /** Placeholder text when empty */
+  placeholder?: string;
+  /** Aria label for accessibility */
+  ariaLabel?: string;
+}
+
+/**
+ * React code editor component
+ */
+export function CodeEditor({
+  className,
+  placeholder,
+  ariaLabel = "Code editor",
+  onChange,
+  ...options
+}: CodeEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { editor, state, setContent } = useEditor({ ...options, onChange });
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      setContent(e.target.value);
+    },
+    [setContent]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const textarea = e.currentTarget;
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const tabSize = editor.getOptions().tabSize;
+        const tab = " ".repeat(tabSize);
+
+        const newValue =
+          state.content.substring(0, start) +
+          tab +
+          state.content.substring(end);
+
+        setContent(newValue);
+
+        requestAnimationFrame(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + tabSize;
+        });
+      }
+    },
+    [editor, state.content, setContent]
+  );
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.value = state.content;
+    }
+  }, [state.content]);
+
+  return (
+    <div className={className} style={{ position: "relative" }}>
+      <textarea
+        ref={textareaRef}
+        defaultValue={state.content}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => editor.focus()}
+        onBlur={() => editor.blur()}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        readOnly={options.readOnly}
+        spellCheck={false}
+        style={{
+          width: "100%",
+          minHeight: "200px",
+          fontFamily: "monospace",
+          fontSize: "14px",
+          lineHeight: "1.5",
+          padding: "12px",
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+          resize: "vertical",
+          tabSize: editor.getOptions().tabSize,
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,3 @@
+export { CodeEditor } from "./CodeEditor";
+export { useEditor } from "./useEditor";
+export type { CodeEditorProps } from "./CodeEditor";

--- a/packages/react/src/useEditor.ts
+++ b/packages/react/src/useEditor.ts
@@ -1,0 +1,66 @@
+import { useRef, useState, useCallback, useEffect } from "react";
+import { Editor, type EditorOptions, type EditorState } from "@teppan/core";
+
+export interface UseEditorOptions extends EditorOptions {
+  onChange?: (content: string) => void;
+}
+
+export interface UseEditorReturn {
+  editor: Editor;
+  state: EditorState;
+  setContent: (content: string) => void;
+  insertText: (text: string) => void;
+  getContent: () => string;
+}
+
+/**
+ * React hook for using the headless editor
+ */
+export function useEditor(options: UseEditorOptions = {}): UseEditorReturn {
+  const { onChange, ...editorOptions } = options;
+
+  const editorRef = useRef<Editor | null>(null);
+
+  const [state, setState] = useState<EditorState>(() => {
+    const editor = new Editor(editorOptions, {
+      onChange: (content) => {
+        setState(editor.getState());
+        onChange?.(content);
+      },
+      onCursorChange: () => {
+        setState(editor.getState());
+      },
+      onSelectionChange: () => {
+        setState(editor.getState());
+      },
+    });
+    editorRef.current = editor;
+    return editor.getState();
+  });
+
+  useEffect(() => {
+    return () => {
+      editorRef.current?.destroy();
+    };
+  }, []);
+
+  const setContent = useCallback((content: string) => {
+    editorRef.current?.setContent(content);
+  }, []);
+
+  const insertText = useCallback((text: string) => {
+    editorRef.current?.insertText(text);
+  }, []);
+
+  const getContent = useCallback(() => {
+    return editorRef.current?.getContent() ?? "";
+  }, []);
+
+  return {
+    editor: editorRef.current!,
+    state,
+    setContent,
+    insertText,
+    getContent,
+  };
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import dts from "vite-plugin-dts";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    dts({
+      include: ["src"],
+      outDir: "dist",
+    }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      formats: ["es"],
+      fileName: "index",
+    },
+    rollupOptions: {
+      external: ["react", "react-dom", "react/jsx-runtime", "@teppan/core"],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+        },
+      },
+    },
+  },
+});

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@teppan/svelte",
+  "version": "0.0.1",
+  "description": "Svelte 5 bindings for the Teppan code editor. Provides Svelte components with runes support for integrating the editor into Svelte applications.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/teppan.git",
+    "directory": "packages/svelte"
+  },
+  "keywords": [
+    "teppan",
+    "code-editor",
+    "editor",
+    "svelte",
+    "svelte5",
+    "runes",
+    "typescript"
+  ],
+  "svelte": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "test": "bun test",
+    "typecheck": "svelte-check --tsconfig ./tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "svelte": "^5.0.0"
+  },
+  "dependencies": {
+    "@teppan/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.2",
+    "svelte": "^5.14.1",
+    "svelte-check": "^4.1.1",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5",
+    "vite-plugin-dts": "^4.3.0"
+  }
+}

--- a/packages/svelte/src/CodeEditor.svelte
+++ b/packages/svelte/src/CodeEditor.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { createEditor, type CreateEditorOptions } from "./createEditor.svelte";
+  import { untrack } from "svelte";
+
+  interface Props {
+    value?: string;
+    language?: string;
+    readOnly?: boolean;
+    tabSize?: number;
+    lineNumbers?: boolean;
+    wordWrap?: boolean;
+    placeholder?: string;
+    ariaLabel?: string;
+    onchange?: (value: string) => void;
+  }
+
+  let {
+    value = $bindable(""),
+    language = "plaintext",
+    readOnly = false,
+    tabSize = 2,
+    lineNumbers = true,
+    wordWrap = false,
+    placeholder = "",
+    ariaLabel = "Code editor",
+    onchange,
+  }: Props = $props();
+
+  // Capture initial values for editor initialization (intentionally non-reactive)
+  const initialOptions: CreateEditorOptions = untrack(() => ({
+    initialContent: value,
+    language,
+    readOnly,
+    tabSize,
+    lineNumbers,
+    wordWrap,
+    onChange: (content: string) => {
+      value = content;
+      onchange?.(content);
+    },
+  }));
+
+  const { editor, state: editorState, setContent } = createEditor(initialOptions);
+
+  $effect(() => {
+    if (value !== editorState.content) {
+      setContent(value);
+    }
+  });
+
+  function handleInput(e: Event) {
+    const target = e.target as HTMLTextAreaElement;
+    setContent(target.value);
+  }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      const textarea = e.target as HTMLTextAreaElement;
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      const currentTabSize = editor.getOptions().tabSize;
+      const tab = " ".repeat(currentTabSize);
+
+      const newValue =
+        editorState.content.substring(0, start) +
+        tab +
+        editorState.content.substring(end);
+
+      setContent(newValue);
+
+      requestAnimationFrame(() => {
+        textarea.selectionStart = textarea.selectionEnd = start + currentTabSize;
+      });
+    }
+  }
+</script>
+
+<div class="teppan-editor">
+  <textarea
+    value={editorState.content}
+    {placeholder}
+    aria-label={ariaLabel}
+    readonly={readOnly}
+    spellcheck="false"
+    oninput={handleInput}
+    onkeydown={handleKeyDown}
+    onfocus={() => editor.focus()}
+    onblur={() => editor.blur()}
+    style="tab-size: {tabSize}"
+  ></textarea>
+</div>
+
+<style>
+  .teppan-editor {
+    position: relative;
+  }
+
+  .teppan-editor textarea {
+    width: 100%;
+    min-height: 200px;
+    font-family: monospace;
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    resize: vertical;
+  }
+</style>

--- a/packages/svelte/src/createEditor.svelte.ts
+++ b/packages/svelte/src/createEditor.svelte.ts
@@ -1,0 +1,72 @@
+import { Editor, type EditorOptions, type EditorState } from "@teppan/core";
+import { onDestroy } from "svelte";
+
+export interface CreateEditorOptions extends EditorOptions {
+  onChange?: (content: string) => void;
+}
+
+export interface CreateEditorReturn {
+  editor: Editor;
+  state: EditorState;
+  setContent: (content: string) => void;
+  insertText: (text: string) => void;
+  getContent: () => string;
+}
+
+/**
+ * Svelte 5 function for creating a headless editor with runes
+ */
+export function createEditor(
+  options: CreateEditorOptions = {}
+): CreateEditorReturn {
+  const { onChange, ...editorOptions } = options;
+
+  let state = $state<EditorState>({
+    content: options.initialContent ?? "",
+    cursor: { line: 0, column: 0 },
+    selection: null,
+    isDirty: false,
+    language: options.language ?? "plaintext",
+  });
+
+  const editor = new Editor(editorOptions, {
+    onChange: (content) => {
+      state = editor.getState();
+      onChange?.(content);
+    },
+    onCursorChange: () => {
+      state = editor.getState();
+    },
+    onSelectionChange: () => {
+      state = editor.getState();
+    },
+  });
+
+  state = editor.getState();
+
+  onDestroy(() => {
+    editor.destroy();
+  });
+
+  const setContent = (content: string) => {
+    editor.setContent(content);
+  };
+
+  const insertText = (text: string) => {
+    editor.insertText(text);
+  };
+
+  const getContent = () => {
+    return editor.getContent();
+  };
+
+  return {
+    editor,
+    get state() {
+      return state;
+    },
+    setContent,
+    insertText,
+    getContent,
+  };
+}

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,0 +1,3 @@
+export { default as CodeEditor } from "./CodeEditor.svelte";
+export { createEditor } from "./createEditor.svelte";
+export type { CreateEditorOptions, CreateEditorReturn } from "./createEditor.svelte";

--- a/packages/svelte/svelte.config.js
+++ b/packages/svelte/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+export default {
+  preprocess: vitePreprocess(),
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*", "src/**/*.svelte"]
+}

--- a/packages/svelte/vite.config.ts
+++ b/packages/svelte/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import dts from "vite-plugin-dts";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  plugins: [
+    svelte({
+      compilerOptions: {
+        runes: true,
+      },
+    }),
+    dts({
+      include: ["src"],
+      outDir: "dist",
+    }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      formats: ["es"],
+      fileName: "index",
+    },
+    rollupOptions: {
+      external: ["svelte", "svelte/internal", "@teppan/core"],
+    },
+  },
+});

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@teppan/vue",
+  "version": "0.0.1",
+  "description": "Vue 3 bindings for the Teppan code editor. Provides Vue components and composables for integrating the editor into Vue applications.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seijikohara/teppan.git",
+    "directory": "packages/vue"
+  },
+  "keywords": [
+    "teppan",
+    "code-editor",
+    "editor",
+    "vue",
+    "vue3",
+    "typescript"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "test": "bun test",
+    "typecheck": "vue-tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.0"
+  },
+  "dependencies": {
+    "@teppan/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5",
+    "vite-plugin-dts": "^4.3.0",
+    "vue": "^3.5.13",
+    "vue-tsc": "^2.2.0"
+  }
+}

--- a/packages/vue/src/CodeEditor.vue
+++ b/packages/vue/src/CodeEditor.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { watch } from "vue";
+import { useEditor, type UseEditorOptions } from "./useEditor";
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: "",
+  },
+  language: {
+    type: String,
+    default: "plaintext",
+  },
+  readOnly: {
+    type: Boolean,
+    default: false,
+  },
+  tabSize: {
+    type: Number,
+    default: 2,
+  },
+  lineNumbers: {
+    type: Boolean,
+    default: true,
+  },
+  wordWrap: {
+    type: Boolean,
+    default: false,
+  },
+  placeholder: {
+    type: String,
+    default: "",
+  },
+  ariaLabel: {
+    type: String,
+    default: "Code editor",
+  },
+});
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string): void;
+  (e: "change", value: string): void;
+}>();
+
+const editorOptions: UseEditorOptions = {
+  initialContent: props.modelValue,
+  language: props.language,
+  readOnly: props.readOnly,
+  tabSize: props.tabSize,
+  lineNumbers: props.lineNumbers,
+  wordWrap: props.wordWrap,
+  onChange: (content) => {
+    emit("update:modelValue", content);
+    emit("change", content);
+  },
+};
+
+const { editor, state, setContent } = useEditor(editorOptions);
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    if (newValue !== state.value.content) {
+      setContent(newValue);
+    }
+  }
+);
+
+const handleInput = (e: Event) => {
+  const target = e.target as HTMLTextAreaElement;
+  setContent(target.value);
+};
+
+const handleKeyDown = (e: KeyboardEvent) => {
+  if (e.key === "Tab") {
+    e.preventDefault();
+    const textarea = e.target as HTMLTextAreaElement;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const tabSize = editor.value.getOptions().tabSize;
+    const tab = " ".repeat(tabSize);
+
+    const newValue =
+      state.value.content.substring(0, start) +
+      tab +
+      state.value.content.substring(end);
+
+    setContent(newValue);
+
+    requestAnimationFrame(() => {
+      textarea.selectionStart = textarea.selectionEnd = start + tabSize;
+    });
+  }
+};
+</script>
+
+<template>
+  <div class="teppan-editor">
+    <textarea
+      :value="state.content"
+      :placeholder="placeholder"
+      :aria-label="ariaLabel"
+      :readonly="readOnly"
+      spellcheck="false"
+      @input="handleInput"
+      @keydown="handleKeyDown"
+      @focus="editor.focus()"
+      @blur="editor.blur()"
+    />
+  </div>
+</template>
+
+<style scoped>
+.teppan-editor {
+  position: relative;
+}
+
+.teppan-editor textarea {
+  width: 100%;
+  min-height: 200px;
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  resize: vertical;
+  tab-size: v-bind("tabSize");
+}
+</style>

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,3 @@
+export { default as CodeEditor } from "./CodeEditor.vue";
+export { useEditor } from "./useEditor";
+export type { UseEditorOptions, UseEditorReturn } from "./useEditor";

--- a/packages/vue/src/shims-vue.d.ts
+++ b/packages/vue/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}

--- a/packages/vue/src/useEditor.ts
+++ b/packages/vue/src/useEditor.ts
@@ -1,0 +1,64 @@
+import { ref, shallowRef, onUnmounted, type Ref, type ShallowRef } from "vue";
+import { Editor, type EditorOptions, type EditorState } from "@teppan/core";
+
+export interface UseEditorOptions extends EditorOptions {
+  onChange?: (content: string) => void;
+}
+
+export interface UseEditorReturn {
+  editor: ShallowRef<Editor>;
+  state: Ref<EditorState>;
+  setContent: (content: string) => void;
+  insertText: (text: string) => void;
+  getContent: () => string;
+}
+
+/**
+ * Vue 3 composable for using the headless editor
+ */
+export function useEditor(options: UseEditorOptions = {}): UseEditorReturn {
+  const { onChange, ...editorOptions } = options;
+
+  const editor = shallowRef<Editor>(null!);
+  const state = ref<EditorState>(null!);
+
+  const editorInstance = new Editor(editorOptions, {
+    onChange: (content) => {
+      state.value = editorInstance.getState();
+      onChange?.(content);
+    },
+    onCursorChange: () => {
+      state.value = editorInstance.getState();
+    },
+    onSelectionChange: () => {
+      state.value = editorInstance.getState();
+    },
+  });
+
+  editor.value = editorInstance;
+  state.value = editorInstance.getState();
+
+  onUnmounted(() => {
+    editor.value?.destroy();
+  });
+
+  const setContent = (content: string) => {
+    editor.value?.setContent(content);
+  };
+
+  const insertText = (text: string) => {
+    editor.value?.insertText(text);
+  };
+
+  const getContent = () => {
+    return editor.value?.getContent() ?? "";
+  };
+
+  return {
+    editor,
+    state,
+    setContent,
+    insertText,
+    getContent,
+  };
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "preserve",
+    "jsxImportSource": "vue"
+  },
+  "include": ["src/**/*", "src/**/*.vue"]
+}

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import dts from "vite-plugin-dts";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    dts({
+      include: ["src"],
+      outDir: "dist",
+    }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      formats: ["es"],
+      fileName: "index",
+    },
+    rollupOptions: {
+      external: ["vue", "@teppan/core"],
+      output: {
+        globals: {
+          vue: "Vue",
+        },
+      },
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
## Summary

- Set up Bun workspaces for monorepo structure
- Add `@teppan/core`: framework-agnostic headless editor core with state management, text manipulation, and event handling
- Add `@teppan/react`: React 18/19 bindings with `CodeEditor` component and `useEditor` hook
- Add `@teppan/vue`: Vue 3 bindings with `CodeEditor` component and `useEditor` composable
- Add `@teppan/svelte`: Svelte 5 bindings with `CodeEditor` component and runes support
- Configure TypeScript, Vite, and Biome for all packages

## Packages

| Package | Description |
|---------|-------------|
| `@teppan/core` | Framework-agnostic headless core |
| `@teppan/react` | React bindings |
| `@teppan/vue` | Vue 3 bindings |
| `@teppan/svelte` | Svelte 5 bindings |

## Test plan

- [x] `bun install` completes successfully
- [x] `bun run build` completes without errors
- [x] `bun run typecheck` passes for all packages