### PR TITLE
fix: CI workflow configuration and build order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -86,7 +88,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: wasm32-unknown-unknown
+          target: wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  ci:
+    name: CI
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -27,81 +35,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run tests
-        run: bun test --recursive
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run Biome lint
+      - name: Lint
         run: bunx @biomejs/biome check .
 
-  typecheck:
-    name: Type Check
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build packages
+      - name: Build
         run: bun run build
 
-      - name: Run type check
+      - name: Type check
         run: bun run typecheck
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build all packages
-        run: bun run build
+      - name: Test
+        run: bun test --recursive

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "keywords": ["code-editor", "editor", "headless", "typescript"],
   "workspaces": ["packages/*", "packages/bindings/*", "examples/*"],
   "scripts": {
-    "build": "bun run --filter '*' build",
+    "build": "bun run --filter '@teppan/state' build && bun run --filter '@teppan/theme' build && bun run --filter '@teppan/wasm-core' build && bun run --filter '@teppan/view' build && bun run --filter '@teppan/highlight' build && bun run --filter '@teppan/react' build && bun run --filter '@teppan/vue' build && bun run --filter '@teppan/svelte' build && bun run --filter '@teppan/example-*' build",
     "dev": "bun run --filter '*' dev",
     "test": "bun run --filter '*' test",
     "lint": "bun run --filter '*' lint",

--- a/packages/wasm-core/Cargo.toml
+++ b/packages/wasm-core/Cargo.toml
@@ -21,3 +21,6 @@ wasm-bindgen-test = "0.3"
 [profile.release]
 opt-level = "s"
 lto = true
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
## Summary

This PR resolves CI workflow failures and improves the build configuration.

### Changes

- **Rust toolchain action**: Use `actions-rust-lang/setup-rust-toolchain@v1`
  - Provides built-in caching and problem matchers
  - Specifies `wasm32-unknown-unknown` target
- **Sequential build order**: Enforce dependency-based build order in `package.json`
  - Bun workspaces do not support topological ordering
  - Packages now build sequentially: state/theme/wasm-core → view/highlight → bindings → examples
- **Single CI job**: Consolidate all CI steps into one job
  - Simpler workflow configuration
  - Consistent execution order
- **wasm-opt disabled**: Added `wasm-opt = false` to `Cargo.toml`
  - Prevents binaryen download failures during CI builds

### References

- [actions-rust-lang/setup-rust-toolchain](https://github.com/actions-rust-lang/setup-rust-toolchain)

## Test Plan

- [x] All CI steps (lint, build, typecheck, test) pass successfully